### PR TITLE
Add BuiltWithDot.Net badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Max Capacity
+[![BuiltWithDot.Net shield](https://builtwithdot.net/project/5737/max-capacity/badge)](https://builtwithdot.net/project/5737/max-capacity)
 
 **The ultimate factory management challenge.**  
 


### PR DESCRIPTION
Since Max Capacity is listed on BuiltWithDot.Net I've taken the liberty to raise a PR that adds the BuiltWithDot.Net badge for Max Capacity to the README.md file. This will help promote your project, BuiltWithDot.Net, all other .NET developers that have projects listed on the site, and the open-source .NET ecosystem in general. If you have any questions or concerns, please let me know. Your help is much appreciated!

Thanks, Corstiaan (creator of BuiltWithDot.Net)

PS If you don't want to add the badge, that's totally fine. Just close this PR. No hard feelings :-)